### PR TITLE
fix: crossOrigin error

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -11,7 +11,7 @@ export default function RootLayout({ children }) {
       <head>
         <link rel="icon" href={AppwriteIcon} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link
           href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:opsz,wght@14..32,100..900&family=Poppins:wght@300;400&display=swap"
           rel="stylesheet"


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

crossOrigin is a non-boolean attribute so passing `crossOrigin` results in error:

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/b1fab9ba-8e43-4bb5-b0e6-836a66517f16" />


Instead, we need to pass an empty string.


## Test Plan

Manually tested and got no errors:

<img width="778" alt="image" src="https://github.com/user-attachments/assets/e9916832-533f-4147-9ffc-e6dee4c58815" />

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes