### PR TITLE
fix: hydration error

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,3 @@
-import AppwriteIcon from "../static/appwrite-icon.svg";
-
 export const metadata = {
   title: "Appwrite + Next.js",
   description: "Appwrite starter for Next.js",
@@ -9,7 +7,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <head>
-        <link rel="icon" href={AppwriteIcon} />
+        <link rel="icon" href="/appwrite.svg" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
         <link


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Using an SVG results in hydration error:

<img width="1666" alt="image" src="https://github.com/user-attachments/assets/a7e7cc13-fe90-49dc-98ca-70669de5f504" />

Since the file is already in the public folder, we can just reference it

## Test Plan

Tested manually and got 0 errors:

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/d981fd3d-fb7f-4861-8d17-ec43b28c07e0" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes